### PR TITLE
feat: add address form to index

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,7 +8,9 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
+import { ColorSchemeScript, MantineProvider } from '@mantine/core';
 
+import '@mantine/core/styles.css';
 import "./styles/normalize.css"
 import "./styles/root.css"
 
@@ -24,12 +26,15 @@ export default function App() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
+        <ColorSchemeScript />
       </head>
       <body>
-        <Outlet />
-        <ScrollRestoration />
-        <Scripts />
-        <LiveReload />
+        <MantineProvider>
+          <Outlet />
+          <ScrollRestoration />
+          <Scripts />
+          <LiveReload />
+        </MantineProvider>
       </body>
     </html>
   );

--- a/app/routes/_index/coming-soon.module.css
+++ b/app/routes/_index/coming-soon.module.css
@@ -1,4 +1,0 @@
-.largeWhiteText {
-    font-size: 48px;
-    color: white;
-}

--- a/app/routes/_index/coming-soon.tsx
+++ b/app/routes/_index/coming-soon.tsx
@@ -1,7 +1,0 @@
-import styles from "./coming-soon.module.css";
-
-export function ComingSoon() {
-  return (
-      <h1 className={styles.largeWhiteText}>Coming Soon...</h1>
-  );
-}

--- a/app/routes/_index/enter-your-address-form.tsx
+++ b/app/routes/_index/enter-your-address-form.tsx
@@ -1,0 +1,94 @@
+import { Form } from "@remix-run/react";
+import type { HTMLFormMethod } from "@remix-run/router"
+import { Alert, Button, NumberInput, Select, Stack, TextInput, Title } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
+import { StreetDirection, StreetType } from './enums';
+
+export interface EnterYourAddressFormProps {
+    formProps: {
+        action?: string;
+        method?: HTMLFormMethod;
+        replace?: boolean;
+    }
+    initialValues?: {
+        streetNumber?: number;
+        streetDirection?: StreetDirection;
+        streetName?: string;
+        streetType?: StreetType;
+        unitNumber?: number;
+    }
+}
+
+export function EnterYourAddressForm({ formProps, initialValues = {} }: EnterYourAddressFormProps) {
+    return (
+        <>
+            <Title order={1}>Enter Your Address</Title>
+            <Form {...formProps}>
+                <Stack>
+                    <NumberInput label="Street Number" name="streetNumber" defaultValue={initialValues.streetNumber} maxLength={5} minLength={1} required />
+
+                    <Select label="Street Direction" name="streetDirection" defaultValue={initialValues.streetDirection} data={Object.entries(streetDirectionOptions).map(([label, value]) => ({ value, label }))} />
+
+                    <TextInput label="Street Name" name="streetName" defaultValue={initialValues.streetName} minLength={1} required />
+
+                    <Select label="Street Type" name="streetType" defaultValue={initialValues.streetType} data={Object.entries(streetTypeOptions).map(([label, value]) => ({ value, label }))} />
+
+                    <NumberInput label="Unit Number" name="unitNumber" defaultValue={initialValues.unitNumber} maxLength={5} minLength={1} />
+
+                    <Alert variant="light" radius="xs" title="Sorry for the dust!" withCloseButton icon={<IconInfoCircle />}>
+                        I don't (yet) have a sophisticated way to parse a full street address written in a more natural form
+                        (e.g. "1234 E Main St Apt 2"). So, for now, please enter your address in the format above. Thanks!
+                    </Alert>
+
+                    <Button type="submit" fullWidth>Submit</Button>
+                </Stack>
+            </Form>
+        </>
+    )
+}
+
+const streetTypeOptions = {
+    "Alley": StreetType.Alley,
+    "Avenue": StreetType.Avenue,
+    "Boulevard": StreetType.Boulevard,
+    "Bend": StreetType.Bend,
+    "Circle": StreetType.Circle,
+    "Crescent": StreetType.Crescent,
+    "Court": StreetType.Court,
+    "Drive": StreetType.Drive,
+    "Glen": StreetType.Glen,
+    "Green": StreetType.Green,
+    "Heights": StreetType.Heights,
+    "Highway": StreetType.Highway,
+    "Lane": StreetType.Lane,
+    "Loop": StreetType.Loop,
+    "Mall": StreetType.Mall,
+    "Pass": StreetType.Pass,
+    "Path": StreetType.Path,
+    "Parkway": StreetType.Parkway,
+    "Place": StreetType.Place,
+    "Plaza": StreetType.Plaza,
+    "Ramp": StreetType.Ramp,
+    "Road": StreetType.Road,
+    "Ridge": StreetType.Ridge,
+    "Row": StreetType.Row,
+    "RR": StreetType.RR,
+    "Run": StreetType.Run,
+    "Spur": StreetType.Spur,
+    "Square": StreetType.Square,
+    "Street": StreetType.Street,
+    "Terrace": StreetType.Terrace,
+    "Trace": StreetType.Trace,
+    "Trail": StreetType.Trail,
+    "View": StreetType.View,
+    "Walk": StreetType.Walk,
+    "Way": StreetType.Way,
+    "Crossing": StreetType.Crossing,
+} as const
+
+const streetDirectionOptions = {
+    "North": StreetDirection.North,
+    "South": StreetDirection.South,
+    "East": StreetDirection.East,
+    "West": StreetDirection.West,
+} as const

--- a/app/routes/_index/enums.ts
+++ b/app/routes/_index/enums.ts
@@ -1,0 +1,52 @@
+/**
+ * Street type values shared across the front and backend.
+ * For official word <-> abrv mappings, see https://pe.usps.com/text/pub28/28apc_002.htm
+ */
+export const enum StreetType {
+    "Alley" = "Aly",
+    "Avenue" = "Ave",
+    "Boulevard" = "Blvd",
+    "Bend" = "Bnd",
+    "Circle" = "Cir",
+    "Crescent" = "Cres",
+    "Court" = "Ct",
+    "Drive" = "Dr",
+    "Glen" = "Gln",
+    "Green" = "Grn",
+    "Heights" = "Hts",
+    "Highway" = "Hwy",
+    "Lane" = "Ln",
+    "Loop" = "Loop",
+    "Mall" = "Mall",
+    "Pass" = "Pass",
+    "Path" = "Path",
+    "Parkway" = "Pkwy",
+    "Place" = "Pl",
+    "Plaza" = "Plz",
+    "Ramp" = "Ramp",
+    "Road" = "Rd",
+    "Ridge" = "Rdg",
+    "Row" = "Row",
+    "RR" = "RR",
+    "Run" = "Run",
+    "Spur" = "Spur",
+    "Square" = "Sq",
+    "Street" = "St",
+    "Terrace" = "Ter",
+    "Trace" = "Trce",
+    "Trail" = "Trl",
+    "View" = "Vw",
+    "Walk" = "Walk",
+    "Way" = "Way",
+    "Crossing" = "Xing"
+  }
+
+  /**
+   * Street direction values shared across the front and backend.
+   */
+export const enum StreetDirection {
+    "North" = "N",
+    "South" = "S",
+    "East" = "E",
+    "West" = "W"
+}

--- a/app/routes/_index/enums.ts
+++ b/app/routes/_index/enums.ts
@@ -2,7 +2,7 @@
  * Street type values shared across the front and backend.
  * For official word <-> abrv mappings, see https://pe.usps.com/text/pub28/28apc_002.htm
  */
-export const enum StreetType {
+export enum StreetType {
     "Alley" = "Aly",
     "Avenue" = "Ave",
     "Boulevard" = "Blvd",
@@ -44,7 +44,7 @@ export const enum StreetType {
   /**
    * Street direction values shared across the front and backend.
    */
-export const enum StreetDirection {
+export enum StreetDirection {
     "North" = "N",
     "South" = "S",
     "East" = "E",

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -1,17 +1,23 @@
 import type { MetaFunction } from "@remix-run/cloudflare";
-import { ComingSoon } from "./coming-soon";
+import { EnterYourAddressForm } from "./enter-your-address-form";
+import { Container, Paper } from '@mantine/core';
 
 export const meta: MetaFunction = () => {
   return [
-    { title: "New Remix App" },
-    { name: "description", content: "Welcome to Remix!" },
+    { title: "Trash and Recycling Pickup: Madison WI" },
+    { name: "description", content: "A (more) helpful schedule for browsing your trash and recycle services." },
   ];
 };
 
 export default function Index() {
   return (
-      <div>
-        <ComingSoon />
-      </div>
+    <Container miw={320} maw={1024} w="50%">
+      <Paper shadow="lg" radius="lg" withBorder p="sm">
+        <EnterYourAddressForm formProps={{
+          method: "post",
+          replace: true,
+        }} />
+      </Paper>
+    </Container>
   );
 }

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -1,6 +1,10 @@
-import type { MetaFunction } from "@remix-run/cloudflare";
-import { EnterYourAddressForm } from "./enter-your-address-form";
+import type { ActionFunctionArgs, MetaFunction } from "@remix-run/cloudflare";
 import { Container, Paper } from '@mantine/core';
+import { useActionData } from "@remix-run/react";
+import { zfd } from "zod-form-data";
+import { z } from "zod";
+import { EnterYourAddressForm } from "./enter-your-address-form";
+import { StreetDirection, StreetType } from './enums'
 
 export const meta: MetaFunction = () => {
   return [
@@ -10,14 +14,40 @@ export const meta: MetaFunction = () => {
 };
 
 export default function Index() {
+  const data = useActionData<typeof action>();
+
   return (
     <Container miw={320} maw={1024} w="50%">
       <Paper shadow="lg" radius="lg" withBorder p="sm">
         <EnterYourAddressForm formProps={{
           method: "post",
           replace: true,
-        }} />
+        }} initialValues={data} />
       </Paper>
     </Container>
   );
+}
+
+
+const schema = zfd.formData({
+  streetDirection: zfd.text(z.nativeEnum(StreetDirection).optional()),
+  streetName: zfd.text(z.string().min(1)),
+  streetNumber: zfd.numeric(z.number().min(1).max(99999)),
+  streetType: zfd.text(z.nativeEnum(StreetType).optional()),
+  unitNumber: zfd.numeric(z.number().min(1).max(99999).optional()),
+})
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { streetDirection, streetName, streetNumber, streetType, unitNumber } = schema.parse(await request.formData());
+
+  // TODO: Write a cookie with the address, schedule, etc.
+  // Need to decide what level of information will be stored on the client and
+  // refetched from the service.
+  return {
+    streetDirection,
+    streetName,
+    streetNumber,
+    streetType,
+    unitNumber,
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@tabler/icons-react": "^2.44.0",
         "isbot": "^3.6.8",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "zod-form-data": "^2.0.2"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20230518.0",
@@ -12650,9 +12651,16 @@
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-form-data": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/zod-form-data/-/zod-form-data-2.0.2.tgz",
+      "integrity": "sha512-sKTi+k0fvkxdakD0V5rq+9WVJA3cuTQUfEmNqvHrTzPLvjfLmkkBLfR0ed3qOi9MScJXTHIDH/jUNnEJ3CBX4g==",
+      "peerDependencies": {
+        "zod": ">= 3.11.0"
       }
     },
     "node_modules/zwitch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,17 @@
 {
-  "name": "madison-pickup",
+  "name": "madison-wi-pickup",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.1.3",
+        "@mantine/core": "^7.3.2",
+        "@mantine/hooks": "^7.3.2",
         "@remix-run/cloudflare": "^2.3.1",
         "@remix-run/css-bundle": "^2.3.1",
         "@remix-run/react": "^2.3.1",
+        "@tabler/icons-react": "^2.44.0",
         "isbot": "^3.6.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -20,6 +23,9 @@
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
         "eslint": "^8.38.0",
+        "postcss": "^8.4.32",
+        "postcss-preset-mantine": "^1.12.1",
+        "postcss-simple-vars": "^7.0.1",
         "typescript": "^5.1.6",
         "wrangler": "3.8.0"
       },
@@ -781,7 +787,6 @@
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
       "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1425,6 +1430,54 @@
         "node": ">=14"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+      "dependencies": {
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.8.tgz",
+      "integrity": "sha512-AuYeDoaR8jtUlUXtZ1IJ/6jtBkGnSpJXbGNzokBL87VDJ8opMq1Bgrc0szhK482ReQY6KZsMoZCVSb4xwalkBA==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.1",
+        "aria-hidden": "^1.2.3",
+        "tabbable": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.4.tgz",
+      "integrity": "sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
@@ -1577,6 +1630,43 @@
       "resolved": "https://registry.npmjs.org/@jspm/core/-/core-2.0.1.tgz",
       "integrity": "sha512-Lg3PnLp0QXpxwLIAuuJboLeRaIhrgJjeuh797QADg3xz8wGLugQOS5DpsE8A6i6Adgzf+bacllkKZG3J0tGfDw==",
       "dev": true
+    },
+    "node_modules/@mantine/core": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.3.2.tgz",
+      "integrity": "sha512-CwAuQogVLcLR7O9e1eOgi3gtk4XX6cnaqevAxzJJpIOIyCnHiQ3cEGINVXyUUjUUipBlvK3sqz3NPGJ2ekLFDQ==",
+      "dependencies": {
+        "@floating-ui/react": "^0.24.8",
+        "clsx": "2.0.0",
+        "react-number-format": "^5.3.1",
+        "react-remove-scroll": "^2.5.7",
+        "react-textarea-autosize": "8.5.3",
+        "type-fest": "^3.13.1"
+      },
+      "peerDependencies": {
+        "@mantine/hooks": "7.3.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@mantine/core/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mantine/hooks": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.3.2.tgz",
+      "integrity": "sha512-xgumuuI3PBWXff5N02HCI7PEy25mDEdyXDQklUYK93J6FKwpcosyZnGVitoUrV1gLtYYa9ZudeAWdhHuh/CpOg==",
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
     },
     "node_modules/@mdx-js/mdx": {
       "version": "2.3.0",
@@ -2027,6 +2117,31 @@
       "integrity": "sha512-2/U3GXA6YiPYQDLGwtGlnNgKYBSwCFIHf8Y9LUY5VATHdtbLlU0Y1R3QoBnT0aB4qv/BEiVVsj7LJXoQCgJ2vA==",
       "dev": true
     },
+    "node_modules/@tabler/icons": {
+      "version": "2.44.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.44.0.tgz",
+      "integrity": "sha512-WPPtihDcAwEm1QZM9MXQw6+r/R2/qx7KMU1eegsi9DsqBLAb0W2kbt6e/syvd6j9c+6XNpRVBW1ziGqSWQAWOg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "2.44.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-2.44.0.tgz",
+      "integrity": "sha512-10qwrqJ/QBNgY4YYer9PjWmCwm3wv9aVK8kGAkFKkwu6UJURVLZ2ea+oFh5j6vSXnA1zMtUG+X8anR5fZ67Isw==",
+      "dependencies": {
+        "@tabler/icons": "2.44.0",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
@@ -2154,13 +2269,13 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.39",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.39.tgz",
       "integrity": "sha512-Oiw+ppED6IremMInLV4HXGbfbG6GyziY3kqAwJYOR0PNbkYDmLWQA3a95EhdSmamsvbkJN96ZNN+YD+fGjzSBA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2180,7 +2295,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -2599,6 +2714,22 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aria-hidden/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/aria-query": {
       "version": "5.1.3",
@@ -3103,6 +3234,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001565",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
@@ -3283,6 +3423,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3424,7 +3572,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3627,6 +3775,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/diff": {
       "version": "5.1.0",
@@ -5321,6 +5474,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/get-port": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
@@ -5826,6 +5987,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -8048,7 +8217,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8510,9 +8678,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "dev": true,
       "funding": [
         {
@@ -8529,7 +8697,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -8547,6 +8715,25 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+      "dev": true,
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
       }
     },
     "node_modules/postcss-load-config": {
@@ -8582,6 +8769,28 @@
         "ts-node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/postcss-mixins": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-mixins/-/postcss-mixins-9.0.4.tgz",
+      "integrity": "sha512-XVq5jwQJDRu5M1XGkdpgASqLk37OqkH4JCFDXl/Dn7janOJjCTEKL+36cnRVy7bMtoBzALfO7bV7nTIsFnUWLA==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.11",
+        "postcss-js": "^4.0.0",
+        "postcss-simple-vars": "^7.0.0",
+        "sugarss": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
       }
     },
     "node_modules/postcss-modules": {
@@ -8662,6 +8871,38 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/postcss-nested": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
+      "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.11"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-preset-mantine": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/postcss-preset-mantine/-/postcss-preset-mantine-1.12.1.tgz",
+      "integrity": "sha512-N1biscmlvJHYPWN6znrlFre80wh9baAaMETfERn8acQJykioGYmHIJLpQSwUSxqq/PG8QbayUyOnHgBV/tsZyA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-mixins": "^9.0.4",
+        "postcss-nested": "^6.0.1"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.0"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
@@ -8673,6 +8914,22 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss-simple-vars": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-simple-vars/-/postcss-simple-vars-7.0.1.tgz",
+      "integrity": "sha512-5GLLXaS8qmzHMOjVxqkk1TZPf1jMqesiI7qLhnlyERalG0sMbHIbJqrcnrpmZdKCLglHnRHoEBB61RtGTsj++A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -8826,7 +9083,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -8836,8 +9092,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/property-information": {
       "version": "6.4.0",
@@ -9004,6 +9259,18 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-number-format": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.3.1.tgz",
+      "integrity": "sha512-qpYcQLauIeEhCZUZY9jXZnnroOtdy3jYaS1zQ3M1Sr6r/KMOBEIGNIb7eKT19g2N1wbYgFgvDzs19hw5TrB8XQ==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -9012,6 +9279,61 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
+      "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.4",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/react-remove-scroll/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/react-router": {
       "version": "6.20.0",
@@ -9041,6 +9363,49 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
+      "integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -9092,8 +9457,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",
@@ -10146,6 +10510,22 @@
         "inline-style-parser": "0.1.1"
       }
     },
+    "node_modules/sugarss": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-4.0.1.tgz",
+      "integrity": "sha512-WCjS5NfuVJjkQzK10s8WOBY+hhDxxNt/N6ZaGwxFZ+wN3/lKKFSaaKUNecULcTTvE4urLcKaZFQD8vO0mOZujw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10169,6 +10549,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -10811,6 +11196,94 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-callback-ref/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -10919,9 +11392,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,12 @@
   },
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.1.3",
+    "@mantine/core": "^7.3.2",
+    "@mantine/hooks": "^7.3.2",
     "@remix-run/cloudflare": "^2.3.1",
     "@remix-run/css-bundle": "^2.3.1",
     "@remix-run/react": "^2.3.1",
+    "@tabler/icons-react": "^2.44.0",
     "isbot": "^3.6.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -26,6 +29,9 @@
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "eslint": "^8.38.0",
+    "postcss": "^8.4.32",
+    "postcss-preset-mantine": "^1.12.1",
+    "postcss-simple-vars": "^7.0.1",
     "typescript": "^5.1.6",
     "wrangler": "3.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "@tabler/icons-react": "^2.44.0",
     "isbot": "^3.6.8",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "zod-form-data": "^2.0.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230518.0",

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+    plugins: {
+      "postcss-preset-mantine": {},
+      "postcss-simple-vars": {
+        variables: {
+          "mantine-breakpoint-xs": "36em",
+          "mantine-breakpoint-sm": "48em",
+          "mantine-breakpoint-md": "62em",
+          "mantine-breakpoint-lg": "75em",
+          "mantine-breakpoint-xl": "88em",
+        },
+      },
+    },
+  };

--- a/remix.config.js
+++ b/remix.config.js
@@ -1,5 +1,6 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
+  postcss: true,
   ignoredRouteFiles: ["**/.*"],
   server: "./server.ts",
   serverConditions: ["workerd", "worker", "browser"],


### PR DESCRIPTION
Allows the user to enter their address into a form. Ideally we'd let them type their
address in a fluent format, but to save time we're just going to split it up like the Madison
website requires. Some day we can split the fluent string apart into pieces to work with the
city site.

We've added mantine as a component library and zod for form parsing
and validation.